### PR TITLE
Add Postgres docker compose and secure notifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 # Go build cache & module cache
 *.out
 *.log
-go.sum
 vendor/
 
 # IDE/editor junk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: chatdoc
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+volumes:
+  pgdata:

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/internal/db/notify.go
+++ b/internal/db/notify.go
@@ -1,72 +1,76 @@
 package db
 
 import (
-    "context"
-    "database/sql"
-    "fmt"
-    "log"
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/lib/pq"
 )
 
 // Notifier wraps the LISTEN/NOTIFY mechanism in PostgreSQL.  It can send
 // notifications when summaries are updated and listen for them on the
 // doctor dashboard.  In this skeleton the functionality is simplified.
 type Notifier struct {
-    DB      *sql.DB
-    Channel string
+	DB      *sql.DB
+	Channel string
 }
 
 // NewNotifier constructs a new Notifier.  The channel should match the
 // POSTGRES_NOTIFY_CHANNEL environment variable.
 func NewNotifier(db *sql.DB, channel string) *Notifier {
-    return &Notifier{DB: db, Channel: channel}
+	return &Notifier{DB: db, Channel: channel}
 }
 
 // Notify sends a notification to the specified channel with the session ID.
 func (n *Notifier) Notify(ctx context.Context, sessionID string) error {
-    _, err := n.DB.ExecContext(ctx, fmt.Sprintf("NOTIFY %s, $1", n.Channel), sessionID)
-    return err
+	channel := pq.QuoteIdentifier(n.Channel)
+	_, err := n.DB.ExecContext(ctx, fmt.Sprintf("NOTIFY %s, $1", channel), sessionID)
+	return err
 }
 
 // Listen blocks and yields session IDs as they are received on the channel.
 // It returns a channel of strings.  In a real implementation you would
 // terminate the goroutine when the context is cancelled.
 func (n *Notifier) Listen(ctx context.Context) (<-chan string, error) {
-    // Establish a separate connection to avoid interfering with other queries.
-    conn, err := n.DB.Conn(ctx)
-    if err != nil {
-        return nil, err
-    }
-    // Issue a LISTEN command for the channel.
-    if _, err := conn.ExecContext(ctx, fmt.Sprintf("LISTEN %s", n.Channel)); err != nil {
-        return nil, err
-    }
-    // Create a channel to deliver notifications.
-    ch := make(chan string)
-    go func() {
-        defer func() {
-            _ = conn.Close()
-            close(ch)
-        }()
-        for {
-            // Wait for a notification.  The underlying driver blocks until
-            // a notification is available or the context is cancelled.
-            // pq allows us to use WaitForNotification via a raw connection.
-            // For simplicity we use QueryRow to check for notifications.
-            // In production code, use pgx or LISTEN/NOTIFY support in pq.
-            select {
-            case <-ctx.Done():
-                return
-            default:
-                var sessionID string
-                // Using `SELECT 1` as a dummy to keep the connection alive.
-                if err := conn.QueryRowContext(ctx, "SELECT 1").Scan(new(int)); err != nil {
-                    log.Println("notifier poll error:", err)
-                }
-                // Poll for notifications via pq listener (not implemented in stub).
-                _ = sessionID
-                // In this skeleton we do not deliver notifications.
-            }
-        }
-    }()
-    return ch, nil
+	// Establish a separate connection to avoid interfering with other queries.
+	conn, err := n.DB.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Issue a LISTEN command for the channel.
+	channel := pq.QuoteIdentifier(n.Channel)
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("LISTEN %s", channel)); err != nil {
+		return nil, err
+	}
+	// Create a channel to deliver notifications.
+	ch := make(chan string)
+	go func() {
+		defer func() {
+			_ = conn.Close()
+			close(ch)
+		}()
+		for {
+			// Wait for a notification.  The underlying driver blocks until
+			// a notification is available or the context is cancelled.
+			// pq allows us to use WaitForNotification via a raw connection.
+			// For simplicity we use QueryRow to check for notifications.
+			// In production code, use pgx or LISTEN/NOTIFY support in pq.
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				var sessionID string
+				// Using `SELECT 1` as a dummy to keep the connection alive.
+				if err := conn.QueryRowContext(ctx, "SELECT 1").Scan(new(int)); err != nil {
+					log.Println("notifier poll error:", err)
+				}
+				// Poll for notifications via pq listener (not implemented in stub).
+				_ = sessionID
+				// In this skeleton we do not deliver notifications.
+			}
+		}
+	}()
+	return ch, nil
 }


### PR DESCRIPTION
## Summary
- add docker compose file for local Postgres database
- harden notifier channel usage
- track Go module dependencies

## Testing
- `go vet ./...`
- `go build -v ./cmd/server`


------
https://chatgpt.com/codex/tasks/task_e_689d6eb81f9c8330ac28f53dea31224e