### PR TITLE
docs: align example database URL with docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Example environment configuration for the patient waitroom chatbot
 
 # The database connection string.  Use the format required by lib/pq.
-DATABASE_URL=postgres://user:password@localhost:5432/waitroom?sslmode=disable
+# Defaults correspond to docker-compose.yml (user `postgres`, db `chatdoc`).
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/chatdoc?sslmode=disable
 
 # OpenAI API key used by the LLM worker.  This should be kept secret.
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ waitroom-chatbot/
    ```
 
 2. **Configure the environment**: Copy `.env.example` to `.env` and fill in
-   your database URL and OpenAI API key.  A sample `.env.example` is provided.
+   your database URL and OpenAI API key.  The example configuration uses the
+   default credentials from `docker-compose.yml`
+   (`postgres://postgres:postgres@localhost:5432/chatdoc?sslmode=disable`).
 
 3. **Run the server**: Use the Makefile to build and run the server:
 


### PR DESCRIPTION
## Summary
- update `.env.example` to use postgres default credentials
- document docker-compose database URL in README

## Testing
- `make test`
- `go build ./cmd/server` *(fails: command hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689d939bc2708330bf52de9bf33285ab