### PR TITLE
Redirect users with saved national ID to chat page

### DIFF
--- a/internal/http/templates/patient.html
+++ b/internal/http/templates/patient.html
@@ -1,4 +1,4 @@
-{{ define "patient" }}
+{{ define "patient.html" }}
 <!doctype html>
 <html lang="fa">
 <head>

--- a/internal/http/templates/start.html
+++ b/internal/http/templates/start.html
@@ -1,4 +1,4 @@
-{{ define "start" }}
+{{ define "start.html" }}
 <!doctype html>
 <html lang="fa">
 <head>


### PR DESCRIPTION
## Summary
- Redirect root requests to chat when national ID cookie is present
- Remember national ID after start form submission
- Fix template names so start and chat pages render correctly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d9ebe90c4833081e18c72707421c5