### PR TITLE
Run schema migrations at server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ waitroom-chatbot/
 
    This will start an HTTP server on `:8080` by default.
 
-4. **Apply database migrations**: The `migrations/001_initial.sql` file contains
-   the SQL required to create the initial tables.  You can apply this manually
-   or integrate it into your preferred migration tool.
+4. **Database setup**: The server applies the schema in `internal/db/schema.sql`
+   on startup so the required tables are created automatically. The same SQL is
+   also available in `migrations/001_initial.sql` if you prefer to manage
+   migrations with an external tool.
 
 ### Why Server‑Sent Events (SSE)?
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,6 +42,9 @@ func main() {
 	if err := dbConn.PingContext(ctx); err != nil {
 		log.Fatalf("failed to ping database: %v", err)
 	}
+	if err := db.Migrate(context.Background(), dbConn); err != nil {
+		log.Fatalf("failed to run migrations: %v", err)
+	}
 	repo := db.NewRepository(dbConn)
 	// Initialize LLM client (stub)
 	llmClient := llm.NewOpenAIClient()

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	_ "embed"
+)
+
+//go:embed schema.sql
+var schemaSQL string
+
+// Migrate applies the database schema to the given database. It executes the
+// statements in schema.sql which create tables and types if they do not
+// already exist.
+func Migrate(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, schemaSQL)
+	return err
+}

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS users (
 
 -- messages: chat transcript entries for a session.  The role column
 -- distinguishes between patient and bot messages.
-CREATE TYPE message_role AS ENUM ('patient', 'bot');
+CREATE TYPE IF NOT EXISTS message_role AS ENUM ('patient', 'bot');
 
 CREATE TABLE IF NOT EXISTS messages (
     id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- embed database schema and provide `db.Migrate` helper
- run migrations on server startup to create required tables
- document automatic database setup and ensure schema is idempotent

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da510aa108330bf7f8f0f3d4e3013