### PR TITLE
Fix summaries session_id constraint syntax

### DIFF
--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -38,9 +38,10 @@ CREATE TABLE IF NOT EXISTS messages (
 -- described in the specification.
 CREATE TABLE IF NOT EXISTS summaries (
     id BIGSERIAL PRIMARY KEY,
-    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE UNIQUE,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
     key_points JSONB NOT NULL,
     structured JSONB NOT NULL,
     free_text TEXT NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (session_id)
 );

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -33,9 +33,10 @@ CREATE TABLE IF NOT EXISTS messages (
 
 CREATE TABLE IF NOT EXISTS summaries (
     id BIGSERIAL PRIMARY KEY,
-    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE UNIQUE,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
     key_points JSONB NOT NULL,
     structured JSONB NOT NULL,
     free_text TEXT NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (session_id)
 );


### PR DESCRIPTION
## Summary
- fix SQL syntax for session_id constraint
- ensure single summary per session with table-level UNIQUE

## Testing
- `make test`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da671c6448330a9eb11ba16a8bfc3