### PR TITLE
Show patient messages and add send button

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -130,7 +130,7 @@ func (s *Server) handlePostMessage(w http.ResponseWriter, r *http.Request, natio
 	if count >= s.MessageCap {
 		// send cap message only
 		botMsg, _ := s.Repo.CreateMessage(r.Context(), nationalID, pkg.RoleBot, core.CapMessage)
-		w.Write([]byte(`<div class="message bot">` + botMsg.Content + `</div>`))
+		w.Write([]byte(`<div class="message bot">` + template.HTMLEscapeString(botMsg.Content) + `</div>`))
 		return
 	}
 	// store patient message
@@ -143,5 +143,7 @@ func (s *Server) handlePostMessage(w http.ResponseWriter, r *http.Request, natio
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Write([]byte(`<div class="message bot">` + reply + `</div>`))
+	escContent := template.HTMLEscapeString(content)
+	escReply := template.HTMLEscapeString(reply)
+	w.Write([]byte(`<div class="message patient">` + escContent + `</div><div class="message bot">` + escReply + `</div>`))
 }

--- a/internal/http/templates/patient.html
+++ b/internal/http/templates/patient.html
@@ -24,8 +24,9 @@
       <div class="message {{ .Role }}">{{ .Content }}</div>
       {{ end }}
     </div>
-    <form hx-post="/api/users/{{ .NationalID }}/messages" hx-swap="beforeend" hx-target="#messages">
-      <input name="content" type="text" autocomplete="off" placeholder="پیام خود را بنویسید" />
+    <form hx-post="/api/users/{{ .NationalID }}/messages" hx-swap="beforeend" hx-target="#messages" hx-on::after-request="this.reset()">
+      <input name="content" type="text" autocomplete="off" placeholder="پیام خود را بنویسید" onkeydown="if(event.key==='Enter'){this.form.requestSubmit();event.preventDefault();}" />
+      <button type="submit">ارسال</button>
     </form>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- allow chat form to submit on Enter and via new send button
- return patient and bot messages when sending, escaping content

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689dc4ff5b6883308d5ea5c5db816b2f