### PR TITLE
Improve chat UI and OpenAI integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module waitroom-chatbot
 go 1.20
 
 require github.com/lib/pq v1.10.9 // Postgres driver
+
+require github.com/sashabaranov/go-openai v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/sashabaranov/go-openai v1.18.2 h1:UnC307Mgc+fiIDUmEJCiCvRoMxdFrLtQlg8A594pnG8=
+github.com/sashabaranov/go-openai v1.18.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -143,7 +143,6 @@ func (s *Server) handlePostMessage(w http.ResponseWriter, r *http.Request, natio
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	escContent := template.HTMLEscapeString(content)
 	escReply := template.HTMLEscapeString(reply)
-	w.Write([]byte(`<div class="message patient">` + escContent + `</div><div class="message bot">` + escReply + `</div>`))
+	w.Write([]byte(`<div class="message bot">` + escReply + `</div>`))
 }

--- a/internal/http/templates/patient.html
+++ b/internal/http/templates/patient.html
@@ -5,16 +5,18 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>گفت‌وگوی بیمار</title>
-  <script src="https://unpkg.com/htmx.org@1.9.4"></script>
-  <style>
-    body { font-family: sans-serif; font-size: 1.2rem; line-height: 1.6; direction: rtl; }
-    .chat-box { max-width: 600px; margin: 0 auto; padding: 1rem; }
-    .messages { height: 60vh; overflow-y: auto; border: 1px solid #ddd; padding: 1rem; margin-bottom: 1rem; background: #fafafa; }
-    .message { margin-bottom: .5rem; }
-    .message.bot { color: #0a558d; }
-    .message.patient { color: #0a843a; text-align: right; }
-    input[type="text"] { width: 100%; padding: .5rem; font-size: 1rem; }
-  </style>
+    <script src="https://unpkg.com/htmx.org@1.9.4"></script>
+    <style>
+      body { font-family: sans-serif; font-size: 1.2rem; line-height: 1.6; direction: rtl; background:#f0f4f8; }
+      .chat-box { max-width: 600px; margin: 2rem auto; padding: 1rem; background:#fff; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+      .messages { height: 60vh; overflow-y: auto; border: 1px solid #ddd; padding: 1rem; margin-bottom: 1rem; background: #fafafa; border-radius:4px; }
+      .message { margin-bottom: .5rem; padding:.5rem .75rem; border-radius:6px; max-width:90%; }
+      .message.bot { background:#e7f1ff; color:#0a558d; }
+      .message.patient { background:#e6f5ec; color:#0a843a; text-align: right; margin-left:auto; }
+      input[type="text"] { width: 100%; padding: .5rem; font-size: 1rem; border:1px solid #ccc; border-radius:4px; }
+      button { margin-top:.5rem; padding:.5rem 1rem; font-size:1rem; background:#0a558d; color:#fff; border:none; border-radius:4px; cursor:pointer; }
+      button:disabled { background:#999; cursor:not-allowed; }
+    </style>
 </head>
 <body>
   <div class="chat-box" hx-boost="true">
@@ -24,19 +26,37 @@
       <div class="message {{ .Role }}">{{ .Content }}</div>
       {{ end }}
     </div>
-    <form hx-post="/api/users/{{ .NationalID }}/messages" hx-swap="beforeend" hx-target="#messages" hx-on::after-request="this.reset()">
-      <input name="content" type="text" autocomplete="off" placeholder="پیام خود را بنویسید" onkeydown="if(event.key==='Enter'){this.form.requestSubmit();event.preventDefault();}" />
-      <button type="submit">ارسال</button>
-    </form>
+      <form id="chat-form" hx-post="/api/users/{{ .NationalID }}/messages" hx-swap="beforeend" hx-target="#messages" hx-disabled-elt="#send-btn" hx-on::after-request="this.reset()" hx-on::before-request="appendUserMessage(this)">
+        <input name="content" type="text" autocomplete="off" placeholder="پیام خود را بنویسید" onkeydown="if(event.key==='Enter'){this.form.requestSubmit();event.preventDefault();}" />
+        <button id="send-btn" type="submit">ارسال</button>
+      </form>
   </div>
-  <script>
-    // Auto scroll to bottom on new messages
-    document.body.addEventListener('htmx:afterSwap', function(evt) {
-      if (evt.target.id === 'messages') {
-        evt.target.scrollTop = evt.target.scrollHeight;
+    <script>
+      // Auto scroll to bottom on new messages
+      document.body.addEventListener('htmx:afterSwap', function(evt) {
+        if (evt.target.id === 'messages') {
+          evt.target.scrollTop = evt.target.scrollHeight;
+        }
+      });
+
+      function appendUserMessage(form){
+        var input = form.querySelector('input[name="content"]');
+        var text = input.value.trim();
+        if(text === ''){ return; }
+        var msgs = document.getElementById('messages');
+        var div = document.createElement('div');
+        div.className = 'message patient';
+        div.textContent = text;
+        msgs.appendChild(div);
+        msgs.scrollTop = msgs.scrollHeight;
       }
-    });
-  </script>
+
+      document.getElementById('chat-form').addEventListener('htmx:sendError', function(){
+        var btn = document.getElementById('send-btn');
+        btn.disabled = true;
+        setTimeout(function(){ btn.disabled = false; }, 5000);
+      });
+    </script>
 </body>
 </html>
 {{ end }}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -1,40 +1,81 @@
 package llm
 
 import (
-    "context"
+	"context"
+	"os"
+
+	openai "github.com/sashabaranov/go-openai"
 )
 
 // Client defines the methods required by the chat and summariser.  An
 // implementation could call the OpenAI API or any other LLM provider.
 type Client interface {
-    Chat(ctx context.Context, prompt string) (string, error)
-    Summarize(ctx context.Context, prompt string) (string, error)
+	Chat(ctx context.Context, prompt string) (string, error)
+	Summarize(ctx context.Context, prompt string) (string, error)
 }
 
-// OpenAIClient is a stub implementation of Client that always returns
-// deterministic responses.  Replace this with real calls to the OpenAI API in
-// production.  The API key and model names would normally be supplied via
-// environment variables.
-type OpenAIClient struct{}
+// OpenAIClient calls the OpenAI API for chat and summarisation responses.
+// API credentials and model names are loaded from environment variables.
+type OpenAIClient struct {
+	client       *openai.Client
+	chatModel    string
+	summaryModel string
+}
 
-// NewOpenAIClient constructs a stub LLM client.
+// NewOpenAIClient constructs an OpenAI-backed LLM client.  It reads the API key
+// and model names from the environment and falls back to sensible defaults.
 func NewOpenAIClient() *OpenAIClient {
-    return &OpenAIClient{}
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	c := openai.NewClient(apiKey)
+
+	chatModel := os.Getenv("OPENAI_MODEL_CHAT")
+	if chatModel == "" {
+		chatModel = openai.GPT3Dot5Turbo
+	}
+	summaryModel := os.Getenv("OPENAI_MODEL_SUMMARY")
+	if summaryModel == "" {
+		summaryModel = chatModel
+	}
+
+	return &OpenAIClient{
+		client:       c,
+		chatModel:    chatModel,
+		summaryModel: summaryModel,
+	}
 }
 
-// Chat returns a canned response in Persian based on the prompt.  This stub
-// simply acknowledges the patient message.
+// Chat sends the prompt to the OpenAI chat completion API and returns the
+// model's response.
 func (c *OpenAIClient) Chat(ctx context.Context, prompt string) (string, error) {
-    return "متشکرم از توضیحات شما. لطفاً بیشتر توضیح دهید.", nil
+	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: c.chatModel,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", nil
+	}
+	return resp.Choices[0].Message.Content, nil
 }
 
-// Summarize returns a canned summary.  It returns the prompt truncated to
-// 120 characters.  Replace this with a call to your LLM summarisation model.
+// Summarize generates a short summary of the prompt using the OpenAI API.
 func (c *OpenAIClient) Summarize(ctx context.Context, prompt string) (string, error) {
-    // Return the last 120 runes of the prompt as a fake summary.
-    runes := []rune(prompt)
-    if len(runes) > 120 {
-        runes = runes[:120]
-    }
-    return string(runes), nil
+	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: c.summaryModel,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: "Summarize the following in Persian:"},
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", nil
+	}
+	return resp.Choices[0].Message.Content, nil
 }


### PR DESCRIPTION
## Summary
- Style patient chat page with message bubbles and responsive layout
- Disable send button during requests with retry delay on errors
- Append patient messages immediately and return only bot replies
- Replace stub LLM with real OpenAI API client

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e00b12fbc8330961b829f44d96f75