### PR TITLE
Fix chat endpoint path

### DIFF
--- a/internal/http/templates/patient.html
+++ b/internal/http/templates/patient.html
@@ -29,7 +29,7 @@
 
     <form id="chatForm"
           class="composer"
-          hx-post="/api/sessions/{{ .SessionID }}/messages"
+          hx-post="/api/users/{{ .SessionID }}/messages"
           hx-trigger="submit"
           hx-target="#messages"
           hx-swap="beforeend"


### PR DESCRIPTION
## Summary
- correct chat form submission endpoint to `/api/users/{id}/messages`

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e1cdf04a48330879c744ae2160fee