### PR TITLE
Show recent chat history on load

### DIFF
--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -58,12 +58,13 @@ func (r *Repository) CreateMessage(ctx context.Context, nationalID string, role 
 	return &m, nil
 }
 
-// GetTranscript returns all messages for a user ordered by creation time.
+// GetTranscript returns messages from the last week for a user ordered by creation time.
 func (r *Repository) GetTranscript(ctx context.Context, nationalID string) ([]pkg.Message, error) {
 	rows, err := r.DB.QueryContext(ctx,
 		`SELECT id, national_id, role, content, created_at
          FROM messages
          WHERE national_id = $1
+           AND created_at >= NOW() - INTERVAL '7 days'
          ORDER BY created_at ASC`, nationalID)
 	if err != nil {
 		return nil, err

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -133,7 +133,7 @@ func (s *Server) handlePostMessage(w http.ResponseWriter, r *http.Request, natio
 		// send cap message only
 		botMsg, _ := s.Repo.CreateMessage(r.Context(), nationalID, pkg.RoleBot, core.CapMessage)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write([]byte(`<div class="message bot">` + template.HTMLEscapeString(botMsg.Content) + `</div>`))
+		w.Write([]byte(`<div class="msg bot">` + template.HTMLEscapeString(botMsg.Content) + `</div>`))
 		return
 	}
 	// store patient message
@@ -148,5 +148,5 @@ func (s *Server) handlePostMessage(w http.ResponseWriter, r *http.Request, natio
 	}
 	escReply := template.HTMLEscapeString(reply)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(`<div class="message bot">` + escReply + `</div>`))
+	w.Write([]byte(`<div class="msg bot">` + escReply + `</div>`))
 }

--- a/internal/http/templates/patient.html
+++ b/internal/http/templates/patient.html
@@ -25,7 +25,11 @@
 </head>
 <body>
   <div class="wrap">
-    <div id="messages" class="messages"></div>
+    <div id="messages" class="messages">
+      {{ range .Transcript }}
+        <div class="msg {{ .Role }}">{{ .Content }}</div>
+      {{ end }}
+    </div>
 
     <form id="chatForm"
           class="composer"
@@ -75,6 +79,9 @@
       document.getElementById('messages').appendChild(err);
       scrollToBottom();
     });
+
+    // Scroll to the latest message on initial load
+    scrollToBottom();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Limit stored transcript retrieval to messages from the last week
- Render existing user and bot messages when chat page loads and scroll to the latest message
- Standardize bot reply markup to use `msg` class

## Testing
- `go test ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e29e342ac83308dafce4a1046581f